### PR TITLE
fix: limit hang time to one day

### DIFF
--- a/pipeline/nextflow.config
+++ b/pipeline/nextflow.config
@@ -5,6 +5,7 @@ process {
     errorStrategy = 'retry'       
     maxRetries = 20  
     maxErrors = 100
+    time = 1.d
 }
 process.resourceLabels = ['allen-batch-pipeline': 'aind-pophys-pipeline']
 process {


### PR DESCRIPTION
- Add termination time to `Processing.time` directive in nextflow configuration