### PR TITLE
feat: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    uses: aind/.github/.github/workflows/release-tag-and-publish-pipeline.yml@main


### PR DESCRIPTION
note that this commit is 'feat' and not 'ci', since ci alone does not bump versions.

Merging this will run the release workflow for the first time.